### PR TITLE
chore(eslint): replace console.* with logger (no-console cleanup)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,23 +13,24 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
-    'no-console': 'off',
+    // Phase 1: move selected rules from 'off' to 'warn' to get visibility without failing CI
+    'no-console': 'warn',
     'no-underscore-dangle': 'off',
     'func-names': 'off',
-    'no-param-reassign': 'off',
+    'no-param-reassign': 'warn',
     // relax a few rules to reduce noise for existing codebase
     'max-len': 'off',
     'no-plusplus': 'off',
-    'no-empty': 'off',
+    'no-empty': 'warn',
     'import/extensions': 'off',
     'no-unused-expressions': 'off',
     'class-methods-use-this': 'off',
-    'consistent-return': 'off',
-    'no-unused-vars': 'off',
+    'consistent-return': 'warn',
+    'no-unused-vars': ['warn', { args: 'after-used', vars: 'all', ignoreRestSiblings: true }],
     'import/no-named-as-default': 'off',
     'no-await-in-loop': 'off',
     'no-restricted-syntax': 'off',
-    'no-shadow': 'off',
+    'no-shadow': 'warn',
     'no-mixed-operators': 'off',
     'no-bitwise': 'off',
     'import/prefer-default-export': 'off'

--- a/docs/ESLint-ISSUES.md
+++ b/docs/ESLint-ISSUES.md
@@ -1,0 +1,34 @@
+# ESLint Issues (auto-generated)
+
+Resumen del escaneo actual:
+- Total: **160** problemas (12 errores, 148 advertencias)
+- Problemas potencialmente arreglables con `eslint --fix`: **12**
+
+## Errores (prioridad alta)
+- `object-curly-newline` en tests (`test/pointercoordinator.test.js`, `test/syncbridge.extra.test.js`, etc.) — arreglables con `--fix` (formato de import/objetos multi-linea)
+- `keyword-spacing` en `src/core/Engine.js` (espaciado alrededor de `catch`)
+
+## Advertencias frecuentes
+- `no-empty` (múltiples lugares en `src/core/Engine.js`, componentes y tests)
+- `no-console` (varios usos en `src/ui/*`, `src/utils/chunksManager.js`)
+- `no-unused-vars` (componentes y tests)
+- `no-param-reassign` (varios `Assignment to property of function param` en `src/ui/*` y `src/components/*`)
+- `consistent-return` (métodos async y arrow functions sin return consistente)
+- `no-shadow` (varias sombras de variables locales)
+
+## Sugerencia de workflow (por tarea)
+1. Ejecutar `npm run lint -- --fix` para aplicar correcciones automáticas y reducir errores de formato.
+2. Abrir PR `eslint/fix-formatting` con los cambios resultantes.
+3. Crear PRs específicos por regla (`eslint/fix-no-unused-vars`, `eslint/fix-no-empty`, etc.) con fixes localizados y comentarios claros.
+4. Re-evaluar reglas y pasar de `warn` a `error` cuando el área esté limpia.
+
+## Tareas iniciales propuestas (puedes asignarme para crear PRs):
+- [ ] `format-fix` — run `eslint --fix`, review, open PR
+- [ ] `no-console` — reemplazar o encapsular en `logger.*`, abrir PR con cambios en `src/ui` y `src/utils`
+- [ ] `no-empty` — revisar bloques vacíos y eliminar/añadir comments o comportamiento esperado
+- [ ] `no-unused-vars` — limpiar variables y parámetros no usados
+- [ ] `no-param-reassign` — refactorizar sitios críticos que reassignan parámetros
+
+---
+
+¿Quieres que ejecute `eslint --fix` ahora y abra el PR inicial `eslint/fix-formatting` con los cambios automáticos? Si sí, confirmar y lo hago.

--- a/docs/ESLint-ROADMAP.md
+++ b/docs/ESLint-ROADMAP.md
@@ -1,0 +1,38 @@
+# ESLint Roadmap — Gradual Tightening Plan
+
+Objetivo: aplicar reglas de ESLint de forma incremental para mejorar calidad sin romper flujo de trabajo.
+
+## Fase 1 — Visibilidad (Completado: configuración)
+- [x] Cambiar reglas seleccionadas de `off` a `warn` para obtener señal sin fallos en CI
+  - `no-console` -> `warn`
+  - `no-unused-vars` -> `warn` (args: after-used)
+  - `consistent-return` -> `warn`
+  - `no-param-reassign` -> `warn`
+  - `no-empty` -> `warn`
+  - `no-shadow` -> `warn`
+
+## Fase 2 — Corrección por regla (automatizable)
+- Por cada regla marcada `warn`:
+  - Ejecutar `npm run lint` y generar listado de archivos/errores
+  - Crear PRs pequeños (by-rule) con fixes automáticos (`--fix`) + manual fixes cuando sea necesario
+  - Marcar la regla como `error` o mantener `warn` si no es viable aún
+
+Reglas e issues iniciales propuestos:
+- `no-unused-vars`: limpiar variables no usadas y parámetros (issue: `eslint/no-unused-vars`)
+- `no-console`: reemplazar por `logger.*` cuando aplique o convertir a `logger.debug` (issue: `eslint/no-console`)
+- `no-param-reassign`: evitar reassigns o usar patrones seguros (issue: `eslint/no-param-reassign`)
+- `consistent-return`: detectar funciones inconsistentes y corregir (issue: `eslint/consistent-return`)
+- `no-shadow`: resolver sombras de variables (issue: `eslint/no-shadow`)
+
+## Fase 3 — Harden
+- Una vez que las reglas críticas estén en `error` y la base esté limpia, reducir reglas relaxadas adicionales (ej.: `no-plusplus`, `max-len`) y aplicar formato con `prettier` y `eslint --fix`.
+
+## Tareas operativas
+- [ ] Añadir check de lint en la pipeline CI (workflow que corra `npm run lint && npm run test:run`)
+- [ ] Añadir Issue templates para PRs de "eslint fix: <rule>"
+- [ ] Crear PR inicial: "eslint: phase-1 warnings" con solo cambios de config
+- [ ] Crear script `scripts/eslint-report.js` que genera reporte por regla (opcional)
+
+---
+
+Si confirmas, puedo: 1) ejecutar `npm run lint` ahora para generar el primer reporte y crear issues automáticamente, o 2) comenzar a aplicar fixes automáticos para la regla `no-unused-vars` y abrir el PR correspondiente.

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -42,7 +42,7 @@ export class VisualEngine {
     try {
       const testCanvas = document.createElement('canvas');
       isWebGLAvailable = !!(testCanvas.getContext && (testCanvas.getContext('webgl') || testCanvas.getContext('webgl2')));
-    } catch (e) { isWebGLAvailable = false; }
+    } catch (e) { isWebGLAvailable = false; logger.warn('Three WebGL check failed', e); }
     if (!isWebGLAvailable) {
       this.isHeadless = true;
       // Create a minimal fake renderer to allow audit/tests to proceed without real GL
@@ -434,7 +434,7 @@ export class VisualEngine {
         this.renderer.setPixelRatio(dpr);
         this.renderer.setSize(W, H, false);
         if (this.camera) { this.camera.aspect = W / H; this.camera.updateProjectionMatrix(); }
-      } catch (e) { console.warn('Three resize failed', e); }
+      } catch (e) { logger.warn('Three resize failed', e); }
       // Pixi
       try { if (this.pixiApp && this.pixiApp.renderer) this.pixiApp.renderer.resize(W, H); } catch (e) { try { this._logError(e); logger.warn('Pixi resize failed', e); } catch (err) { /* best-effort */ } }
       // mojs overlay sizing not needed (DOM overlay is 100%)

--- a/src/core/PointerCoordinator.js
+++ b/src/core/PointerCoordinator.js
@@ -8,7 +8,9 @@ export class PointerCoordinator {
   }
 
   getIntersections(event) {
-    const rect = (this.engine && this.engine.renderer && this.engine.renderer.domElement && this.engine.renderer.domElement.getBoundingClientRect && this.engine.renderer.domElement.getBoundingClientRect()) || { left: 0, top: 0, width: 1, height: 1 };
+    const rect = (this.engine && this.engine.renderer && this.engine.renderer.domElement && this.engine.renderer.domElement.getBoundingClientRect && this.engine.renderer.domElement.getBoundingClientRect()) || {
+      left: 0, top: 0, width: 1, height: 1,
+    };
 
     // defensive: avoid division by zero
     if (!rect.width || !rect.height) return null;

--- a/src/core/SyncBridge.js
+++ b/src/core/SyncBridge.js
@@ -146,7 +146,7 @@ export class SyncBridge {
 
     // after hooks
     for (const fn of Array.from(this._after)) {
-      try { fn(dt, this._time); } catch (e) { console.error('SyncBridge after hook error', e); }
+      try { fn(dt, this._time); } catch (e) { try { logger.error('SyncBridge after hook error', e); } catch (err) { /* best-effort */ } }
     }
   }
 
@@ -214,7 +214,7 @@ export class SyncBridge {
     try {
       window.requestAnimationFrame = this._origRAF;
       window.cancelAnimationFrame = this._origCancel;
-    } catch (e) { console.warn('Could not restore native RAF', e); }
+    } catch (e) { try { logger.warn('Could not restore native RAF', e); } catch (err) { /* best-effort */ } }
   }
 
   destroy() {

--- a/src/ui/DragSystem.js
+++ b/src/ui/DragSystem.js
@@ -5,7 +5,7 @@ import * as PIXI from 'pixi.js';
 import logger from '../utils/logger.js';
 
 // lightweight debug helper (global toggle via window.__VISUEFECT.debug)
-const _dbg = (...args) => { try { if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) console.log(...args); } catch (e) {} };
+const _dbg = (...args) => { try { if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) logger.debug(...args); } catch (e) { logger.debug('DragSystem debug helper error', e); } };
 
 /**
  * DragSystem — Smart parser for drag&drop with Ghost previews
@@ -199,7 +199,7 @@ export default class DragSystem {
         const ev = new CustomEvent('drag:imported', { detail: { type: 'gltf', file: f } }); window.dispatchEvent(ev);
       }
     } catch (err) {
-      console.error('3D import error', err);
+      logger.error('3D import error', err);
       URL.revokeObjectURL(url);
     }
   }
@@ -224,7 +224,7 @@ export default class DragSystem {
       setTimeout(() => { try { sprite.parent && sprite.parent.removeChild(sprite); } catch (err) {} }, 8000);
 
       window.dispatchEvent(new CustomEvent('drag:imported', { detail: { type: 'image-sequence', count: textures.length } }));
-    } catch (err) { console.error('Image seq error', err); }
+    } catch (err) { logger.error('Image seq error', err); }
   }
 
   async _handleParticleJSON(file, x, y) {
@@ -238,7 +238,7 @@ export default class DragSystem {
         this.pixiParticles && this.pixiParticles.spawnAt && this.pixiParticles.spawnAt(x + (Math.random() - 0.5) * 120, y + (Math.random() - 0.5) * 120);
       }
       window.dispatchEvent(new CustomEvent('drag:imported', { detail: { type: 'particles-json', file: file.name } }));
-    } catch (err) { console.error('Particle json error', err); }
+    } catch (err) { logger.error('Particle json error', err); }
   }
 
   // ---------- Ghost Preview helpers ----------

--- a/src/ui/Interface.js
+++ b/src/ui/Interface.js
@@ -4,6 +4,7 @@
  * - Se asume que `engine` y los componentes (threeScene, pixiParticles, mojsEffects)
  *   pueden pasarse para que la interfaz actúe sobre ellos.
  */
+import logger from '../utils/logger.js';
 
 export class Interface {
   constructor(engine) {
@@ -17,9 +18,9 @@ export class Interface {
   initEventListeners() {
     if (this._listenersInit) return;
     this._listenersInit = true;
-    if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) console.log('Interface: initEventListeners');
+    if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) logger.debug('Interface: initEventListeners');
     document.querySelectorAll('.step-btn').forEach((btn) => {
-      btn.addEventListener('click', (e) => { try { if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) console.log('Interface: step-btn click', e.currentTarget.dataset.step); this.goToStep(parseInt(e.currentTarget.dataset.step, 10)); } catch (err) { console.warn('Interface step click failed', err); } });
+      btn.addEventListener('click', (e) => { try { if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) logger.debug('Interface: step-btn click', e.currentTarget.dataset.step); this.goToStep(parseInt(e.currentTarget.dataset.step, 10)); } catch (err) { logger.warn('Interface step click failed', err); } });
     });
 
     // Drag & Drop Listener
@@ -50,7 +51,7 @@ export class Interface {
             dbgBtn.textContent = `Debug: ${enabled ? 'On' : 'Off'}`;
             dbgBtn.style.background = enabled ? 'linear-gradient(90deg,#00e676,#00c853)' : '';
             dbgBtn.style.color = enabled ? '#000' : '';
-          } catch (e) { console.warn('debug toggle failed', e); }
+          } catch (e) { logger.warn('debug toggle failed', e); }
         });
       }
     } catch (e) {}
@@ -66,7 +67,7 @@ export class Interface {
       el.addEventListener('dragstart', (ev) => {
         const type = el.getAttribute('data-drag-type') || 'generic';
         const item = el.getAttribute('data-drag-item') || '';
-        if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) console.log('Interface: dragstart', { type, item });
+        if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) logger.debug('Interface: dragstart', { type, item });
         // normalize payload as JSON for cross-browser compatibility
         try { ev.dataTransfer.setData('application/json', JSON.stringify({ type, item })); } catch (e) {}
         // legacy keys for compatibility
@@ -89,7 +90,7 @@ export class Interface {
 
   goToStep(step) {
     this.currentStep = step;
-    if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) console.log(`🚀 VISUEFECT - Paso ${step}: ${this.getStepName(step)}`);
+    if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) logger.info(`🚀 VISUEFECT - Paso ${step}: ${this.getStepName(step)}`);
 
     // Estirar (Stretch): Animamos la transición de la UI con Mo.js
     try { if (window.mojs) new window.mojs.Html({ el: document.body, duration: 350, scale: { 1: 1.01 } }).play(); } catch (e) {}
@@ -139,7 +140,7 @@ export class Interface {
     const rect = document.querySelector('#viewport').getBoundingClientRect();
     const x = e.clientX - rect.left; const y = e.clientY - rect.top;
     if (typeof window !== 'undefined' && window.__VISUEFECT && window.__VISUEFECT.debug) {
-      console.log('Interface: drop', {
+      logger.debug('Interface: drop', {
         type, payload, x, y, types: Array.from(e.dataTransfer.types || []),
       });
     }

--- a/src/ui/Stepper.js
+++ b/src/ui/Stepper.js
@@ -1,4 +1,5 @@
 import mojs from '@mojs/core';
+import logger from '../utils/logger.js';
 
 /**
  * Stepper / WorkflowManager
@@ -295,7 +296,7 @@ export default class Stepper {
       }
       // refresh banner view
       if (this._perfEl && this._perfShown) this._showPerfBanner(parseFloat(this._perfEl.querySelector('#perf-fps').textContent) || 0);
-    } catch (e) { console.warn('Could not remove heavy element', e); }
+    } catch (e) { logger.warn('Could not remove heavy element', e); }
   }
 
   _showElementDetails(item) {
@@ -341,6 +342,6 @@ export default class Stepper {
       }
       // refresh banner
       if (this._perfEl && this._perfShown) this._showPerfBanner(parseFloat(this._perfEl.querySelector('#perf-fps').textContent) || 0);
-    } catch (e) { console.warn('Optimization failed', e); }
+    } catch (e) { logger.warn('Optimization failed', e); }
   }
 }

--- a/src/utils/CodeExporter.js
+++ b/src/utils/CodeExporter.js
@@ -1,3 +1,5 @@
+import logger from './logger.js';
+
 const DEFAULTS = {
   threeUrl: 'https://unpkg.com/three@0.154.0/build/three.module.js',
   pixiUrl: 'https://cdn.jsdelivr.net/npm/pixi.js@7.2.0/dist/browser/pixi.mjs',
@@ -124,7 +126,7 @@ async function ensureAll() {
 
     // attach export util to root for consumer
     container.__visuefect_export = { exportToVideo };
-  })().catch(e=>{ try { globalThis.logger?.error ? globalThis.logger.error('VISUEFECT export init failed', e) : console.error('VISUEFECT export init failed', e); } catch (er) { console.error('VISUEFECT export init failed', e); } });
+  })().catch(e => { try { logger.error('VISUEFECT export init failed', e); } catch (er) { /* ignore */ } });
 })();`;
   }
 

--- a/src/utils/chunksManager.js
+++ b/src/utils/chunksManager.js
@@ -1,3 +1,5 @@
+import logger from './logger.js';
+
 // Utilities to download and upload serialized chunks (base64 payloads)
 export function downloadChunksAsJson(chunks = [], name = 'visuefect_chunks') {
   try {
@@ -6,7 +8,7 @@ export function downloadChunksAsJson(chunks = [], name = 'visuefect_chunks') {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a'); a.href = url; a.download = `${name}.json`; a.click(); URL.revokeObjectURL(url);
     return true;
-  } catch (e) { console.warn('downloadChunksAsJson failed', e); return false; }
+  } catch (e) { logger.warn('downloadChunksAsJson failed', e); return false; }
 }
 
 export async function uploadChunks(url, chunks = [], opts = {}) {
@@ -15,7 +17,7 @@ export async function uploadChunks(url, chunks = [], opts = {}) {
     const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body });
     if (!res.ok) throw new Error(`Upload failed ${res.status}`);
     return await res.json();
-  } catch (e) { console.warn('uploadChunks failed', e); throw e; }
+  } catch (e) { logger.warn('uploadChunks failed', e); throw e; }
 }
 
 export async function uploadFramesAsZip(url, frames = [], fps = 60) {
@@ -27,5 +29,5 @@ export async function uploadFramesAsZip(url, frames = [], fps = 60) {
     // expect server to return a downloadable file (Blob url or object)
     const blob = await res.blob();
     return blob;
-  } catch (e) { console.warn('uploadFramesAsZip failed', e); throw e; }
+  } catch (e) { logger.warn('uploadFramesAsZip failed', e); throw e; }
 }

--- a/test/pointercoordinator.test.js
+++ b/test/pointercoordinator.test.js
@@ -1,10 +1,18 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
 import { PointerCoordinator } from '../src/core/PointerCoordinator.js';
 
 function makeEngine() {
   return {
-    renderer: { domElement: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 100, height: 100 }) } },
+    renderer: {
+      domElement: {
+        getBoundingClientRect: () => ({
+          left: 0, top: 0, width: 100, height: 100,
+        }),
+      },
+    },
     camera: {},
     scene: { children: [] },
     // provide pixi mock shape
@@ -41,7 +49,9 @@ describe('PointerCoordinator', () => {
   });
 
   it('is defensive with zero-sized DOM rect', () => {
-    engine.renderer.domElement.getBoundingClientRect = () => ({ left: 0, top: 0, width: 0, height: 0 });
+    engine.renderer.domElement.getBoundingClientRect = () => ({
+      left: 0, top: 0, width: 0, height: 0,
+    });
     const res = pc.getIntersections({ clientX: 10, clientY: 10 });
     expect(res).toBe(null);
   });

--- a/test/syncbridge.extra.test.js
+++ b/test/syncbridge.extra.test.js
@@ -1,5 +1,7 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
 import SyncBridge from '../src/core/SyncBridge.js';
 
 describe('SyncBridge extra', () => {


### PR DESCRIPTION
Replaces project console.log/warn/error with  where appropriate. This reduces noise and centralizes logging for post-mortem diagnostics. See  for follow-ups.